### PR TITLE
Use composer cache

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,9 +45,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache-directory.outputs.dir }}
-        key: php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+        key: php-${{ matrix.php-versions }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          php-${{ matrix.php-version }}-composer
+          php-${{ matrix.php-versions }}-composer
 
     - name: Compose setup
       run: |


### PR DESCRIPTION
`succeeded 2 minutes ago in 21s` (7.4, no cache) vs `succeeded now in 16s` (with cache)