### PR TITLE
ImageGD: imagecreatetruecolor returns false on errors

### DIFF
--- a/classes/utils/ImageGD.class.php
+++ b/classes/utils/ImageGD.class.php
@@ -42,9 +42,9 @@ class ImageGD extends Image
         $height = round($this->height * $ratio);
 
         // create new image
-        $thumb = ImageCreateTrueColor($width, $height);
+        $thumb = imagecreatetruecolor($width, $height);
 
-        if (!is_resource($thumb)) {
+        if ($thumb === false) {
             return false;
         }
 
@@ -98,9 +98,9 @@ class ImageGD extends Image
         }
 
         // create new image
-        $thumb = ImageCreateTrueColor($width, $height);
+        $thumb = imagecreatetruecolor($width, $height);
 
-        if (!is_resource($thumb)) {
+        if ($thumb === false) {
             return false;
         }
 


### PR DESCRIPTION
https://www.php.net/manual/en/function.imagecreatetruecolor.php

> Returns an image object on success, false on errors.



Version | Description
-- | --
8.0.0 | On success, this function returns a GDImage instance now; previously, a resource was returned.

