### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,4 +72,4 @@ jobs:
         composer install --no-interaction
 
     - name: Test the code
-      run: composer run test
+      run: composer run coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ composer.phar
 *.swp
 
 .coverage/
+.coverage.xml
 .phpunit.result.cache
 
 vendor/

--- a/classes/NanoBaseTest.class.php
+++ b/classes/NanoBaseTest.class.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Base class for PHPUnit-based unit tests
+ *
+ * @codeCoverageIgnore
  */
 class NanoBaseTest extends TestCase
 {

--- a/classes/NanoConsole.class.php
+++ b/classes/NanoConsole.class.php
@@ -7,6 +7,8 @@ use Monolog\Handler\StreamHandler;
 /**
  * Nano console handler
  *
+ * @codeCoverageIgnore
+ *
  * TODO: handle catchable fatals @see http://stackoverflow.com/questions/2468487/how-can-i-catch-a-catchable-fatal-error-on-php-type-hinting
  */
 class NanoConsole

--- a/classes/NanoScript.class.php
+++ b/classes/NanoScript.class.php
@@ -4,6 +4,8 @@ use Nano\NanoObject;
 
 /**
  * General interface for CLI scripts
+ *
+ * @codeCoverageIgnore
  */
 abstract class NanoScript extends NanoObject
 {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
       "phpunit"
     ],
     "coverage": [
-      "phpunit --coverage-html=.coverage"
+      "XDEBUG_MODE=coverage phpunit --coverage-html=.coverage --coverage-clover=.coverage.xml --coverage-text"
     ],
     "lint": [
       "php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --verbose",


### PR DESCRIPTION
* [x] `composer run coverage`

## Current stats

```
 Summary:                    
  Classes: 32.69% (17/52)    
  Methods: 63.03% (283/449)  
  Lines:   62.75% (1373/2188)
```

After 899db0a:

```
 Summary:                    
  Classes: 34.69% (17/49)    
  Methods: 64.98% (282/434)  
  Lines:   65.11% (1370/2104)
```