### PR TITLE
Run linter using PHP 8.1 as well (and fix any issues)

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -14,6 +14,7 @@ jobs:
         - '7.3'
         - '7.4'
         - '8.0'
+        - '8.1'
 
     steps:
     - name: Checkout

--- a/classes/DatabaseResult.class.php
+++ b/classes/DatabaseResult.class.php
@@ -49,7 +49,7 @@ class DatabaseResult implements Iterator, Countable
     /**
      * Return data from current row
      *
-     * @return mixed data
+     * @return array|bool data
      */
     public function fetchRow()
     {
@@ -81,7 +81,7 @@ class DatabaseResult implements Iterator, Countable
     /**
      * Implement Countable interface
      */
-    public function count()
+    public function count(): int
     {
         return $this->numRows();
     }
@@ -89,7 +89,7 @@ class DatabaseResult implements Iterator, Countable
     /**
      * Implement Iterator interface
      */
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->numRows()) {
             $this->seek(0);
@@ -98,6 +98,7 @@ class DatabaseResult implements Iterator, Countable
         $this->currentRow = null;
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (is_null($this->currentRow)) {
@@ -107,11 +108,12 @@ class DatabaseResult implements Iterator, Countable
         return $this->currentRow;
     }
 
-    public function key()
+    public function key(): int
     {
         return $this->pos;
     }
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->pos++;
@@ -119,7 +121,7 @@ class DatabaseResult implements Iterator, Countable
         return $this->currentRow;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return $this->current() !== false;
     }

--- a/classes/Router.class.php
+++ b/classes/Router.class.php
@@ -279,10 +279,17 @@ class Router
     /**
      * Sanitize given string to be used in URL
      *
-     * Replace all non alphanumeric characters with a dash
+     * Replace all non-alphanumeric characters with a dash
+     *
+     * @param string|null $string
+     * @return string
      */
-    public function sanitize($string)
+    public function sanitize(?string $string): string
     {
+        if (is_null($string)) {
+            return '';
+        }
+
         $string = mb_strtolower(trim($string));
         $string = strtr($string, [
             'ą' => 'a',

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -28,6 +28,7 @@ class RouterTest extends \Nano\NanoBaseTest
     {
         $router = $this->getRouter();
 
+        $this->assertEquals('', $router->sanitize(null));
         $this->assertEquals('foobar', $router->sanitize('foobar'));
         $this->assertEquals('foo-bar', $router->sanitize('foo/bar'));
         $this->assertEquals('foo-bar', $router->sanitize('foo - bar'));


### PR DESCRIPTION
Production (when switched to PHP 8.1) reports:

```
$ cat phperror.log | grep 22-Sep | cut -d] -f2 | sort | uniq
 PHP Deprecated:  Implicit conversion from float 3.5 to int loses precision in /usr/home/macbre/elecena/git/app/controllers/search/SearchController.class.php on line 438
 PHP Deprecated:  Implicit conversion from float 7.5 to int loses precision in /usr/home/macbre/elecena/git/app/controllers/parameters/ParametersController.class.php on line 300
 PHP Deprecated:  Implicit conversion from float 7.5 to int loses precision in /usr/home/macbre/elecena/git/app/controllers/search/SearchController.class.php on line 438
 PHP Deprecated:  Return type of DatabaseResult::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange
 PHP Deprecated:  Return type of DatabaseResult::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange
 PHP Deprecated:  Return type of DatabaseResult::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange
 PHP Deprecated:  Return type of DatabaseResult::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange
 PHP Deprecated:  Return type of DatabaseResult::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange
 PHP Deprecated:  Return type of DatabaseResult::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange
 PHP Deprecated:  Return type of Predis\Client::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange
 PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/home/macbre/elecena/git/app/vendor/elecena/nano/classes/Router.class.php on line 286
 PHP Notice:  ob_end_clean(): Failed to discard buffer of zlib output compression (2) in /usr/home/macbre/elecena/git/app/vendor/elecena/nano/classes/Response.class.php on line 365
```