### PR TITLE
cs-fixer: use new rules

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,11 +8,15 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 
+// https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/index.rst
+// https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/ruleSets/index.rst
 return $config
   ->setRules([
       '@PSR2' => true,
       'array_syntax' => ['syntax' => 'short'],
+      'list_syntax' => true,
+      'ternary_to_null_coalescing' => true,
+      'trailing_comma_in_multiline' => true,
   ])
   ->setFinder($finder)
 ;
-

--- a/app/config/default.config.php
+++ b/app/config/default.config.php
@@ -2,7 +2,7 @@
 
 // debug
 $config['debug'] = [
-    'enabled' => true
+    'enabled' => true,
 ];
 
 $config['assets.packages'] = [

--- a/classes/Cache.class.php
+++ b/classes/Cache.class.php
@@ -35,14 +35,14 @@ abstract class Cache
      */
     public static function factory(array $settings)
     {
-        $driver = isset($settings['driver']) ? $settings['driver'] : null;
+        $driver = $settings['driver'] ?? null;
         $className = sprintf('Nano\\Cache\\Cache%s', ucfirst($driver));
 
         try {
             return new $className($settings);
         } catch (\Exception $e) {
             NanoLogger::getLogger('nano.cache')->error($e->getMessage(), [
-                'exception' => $e
+                'exception' => $e,
             ]);
             throw $e;
         }
@@ -67,7 +67,7 @@ abstract class Cache
         $events->bind('NanoAppTearDown', [$this, 'onNanoAppTearDown']);
 
         // set prefix
-        $this->prefix = isset($settings['prefix']) ? $settings['prefix'] : false;
+        $this->prefix = $settings['prefix'] ?? false;
     }
 
     /**
@@ -191,7 +191,7 @@ abstract class Cache
         $debug->log("Cache: {$this->hits} hits and {$this->misses} misses");
         $this->logger->info('Performance data', [
             'hits' => $this->getHits(),
-            'misses' => $this->getMisses()
+            'misses' => $this->getMisses(),
         ]);
     }
 }

--- a/classes/Database.class.php
+++ b/classes/Database.class.php
@@ -104,7 +104,7 @@ abstract class Database
                 } catch (DatabaseException $e) {
                     $logger->error($e->getMessage(), [
                         'exception' => $e,
-                        'driver' => $className
+                        'driver' => $className,
                     ]);
                     throw $e;
                 }
@@ -527,7 +527,7 @@ abstract class Database
 
         while (true) {
             $column_where = [
-                sprintf('%s > "%s"', $column, $this->escape($start))
+                sprintf('%s > "%s"', $column, $this->escape($start)),
             ];
 
             $ids = $this->selectFields(
@@ -536,7 +536,7 @@ abstract class Database
                 array_merge($column_where, $where),
                 [
                     'order' => $column,
-                    'limit' => intval($batch)
+                    'limit' => intval($batch),
                 ],
                 $fname
             );

--- a/classes/Events.class.php
+++ b/classes/Events.class.php
@@ -33,7 +33,7 @@ class Events
     {
         $this->events[$eventName][] = [
             self::CALLBACK_SIMPLE,
-            $callback
+            $callback,
         ];
     }
 
@@ -46,8 +46,8 @@ class Events
             self::CALLBACK_CONTROLLER,
             [
                 $controllerName,
-                $controllerMethod
-            ]
+                $controllerMethod,
+            ],
         ];
 
         $this->events[$eventName][] = $callback;
@@ -58,21 +58,21 @@ class Events
      */
     public function fire($eventName, $params = [])
     {
-        $callbacks = isset($this->events[$eventName]) ? $this->events[$eventName] : null;
+        $callbacks = $this->events[$eventName] ?? null;
 
         if ($callbacks) {
             foreach ($callbacks as $entry) {
-                list($type, $callback) = $entry;
+                [$type, $callback] = $entry;
 
                 switch ($type) {
                     // lazy load of controllers
                     case self::CALLBACK_CONTROLLER:
-                        list($name, $method) = $callback;
+                        [$name, $method] = $callback;
 
                         $instance = $this->app->getController($name);
                         $callback = [
                             $instance,
-                            $method
+                            $method,
                         ];
                         break;
                 }

--- a/classes/MessageQueue.class.php
+++ b/classes/MessageQueue.class.php
@@ -39,7 +39,7 @@ abstract class MessageQueue
         $this->logger = NanoLogger::getLogger(__CLASS__);
 
         // set prefix
-        $this->prefix = isset($settings['prefix']) ? $settings['prefix'] : false;
+        $this->prefix = $settings['prefix'] ?? false;
     }
 
     /**

--- a/classes/NanoApp.class.php
+++ b/classes/NanoApp.class.php
@@ -115,8 +115,8 @@ class NanoApp
         }
 
         // set request
-        $params = isset($_REQUEST) ? $_REQUEST : [];
-        $env = isset($_SERVER) ? $_SERVER : [];
+        $params = $_REQUEST ?? [];
+        $env = $_SERVER ?? [];
 
         $this->request = new Request($params, $env);
         if (!$this->request->isCLI()) {
@@ -143,7 +143,7 @@ class NanoApp
         // TODO: move to a Monolog processor
         $responseDetails = [
             'time' => $this->getResponse()->getResponseTime() * 1000, // [ms]
-            'response_code' => $this->getResponse()->getResponseCode()
+            'response_code' => $this->getResponse()->getResponseCode(),
         ];
 
         // request type
@@ -346,7 +346,7 @@ class NanoApp
             // log the exception
             $logger = NanoLogger::getLogger('nano.app.exception');
             $logger->error($e->getMessage(), [
-                'exception' => $e
+                'exception' => $e,
             ]);
 
             if (is_callable($handler)) {

--- a/classes/NanoScript.class.php
+++ b/classes/NanoScript.class.php
@@ -44,7 +44,7 @@ abstract class NanoScript extends NanoObject
             $this->init();
         } catch (Exception $e) {
             $this->logger->error(__METHOD__ . ' failed', [
-                'exception' => $e
+                'exception' => $e,
             ]);
         }
     }

--- a/classes/Request.class.php
+++ b/classes/Request.class.php
@@ -42,7 +42,7 @@ class Request
         $this->env = $env;
 
         // detect request type
-        $method = isset($env['REQUEST_METHOD']) ? $env['REQUEST_METHOD'] : false;
+        $method = $env['REQUEST_METHOD'] ?? false;
 
         // CLI mode detection
         if ($method == false && php_sapi_name() == 'cli') {
@@ -193,7 +193,7 @@ class Request
      */
     public function get($param, $default = null)
     {
-        return isset($this->params[$param]) ? $this->params[$param] : $default;
+        return $this->params[$param] ?? $default;
     }
 
     /**
@@ -308,7 +308,7 @@ class Request
     {
         $key = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
 
-        return isset($this->env[$key]) ? $this->env[$key] : $default;
+        return $this->env[$key] ?? $default;
     }
 
     /**
@@ -328,7 +328,7 @@ class Request
         $fields = [
             'HTTP_CLIENT_IP',
             'HTTP_X_FORWARDED_FOR',
-            'REMOTE_ADDR'
+            'REMOTE_ADDR',
         ];
 
         // scan HTTP headers to find IP

--- a/classes/Response.class.php
+++ b/classes/Response.class.php
@@ -153,7 +153,7 @@ class Response
      */
     public function getHeader($name)
     {
-        return isset($this->headers[$name]) ? $this->headers[$name] : null;
+        return $this->headers[$name] ?? null;
     }
 
     /**
@@ -184,7 +184,7 @@ class Response
         header_remove('X-Powered-By');
 
         // emit HTTP protocol and response code
-        $protocol = isset($this->env['SERVER_PROTOCOL']) ? $this->env['SERVER_PROTOCOL'] : 'HTTP/1.1';
+        $protocol = $this->env['SERVER_PROTOCOL'] ?? 'HTTP/1.1';
 
         header("{$protocol} {$this->responseCode}", true /* $replace */, $this->responseCode);
         $this->debug->log(__METHOD__ . " - HTTP {$this->responseCode}");
@@ -282,7 +282,7 @@ class Response
      */
     public function getAcceptedEncoding()
     {
-        $acceptedEncoding = isset($this->env['HTTP_ACCEPT_ENCODING']) ? $this->env['HTTP_ACCEPT_ENCODING'] : '';
+        $acceptedEncoding = $this->env['HTTP_ACCEPT_ENCODING'] ?? '';
 
         if ($acceptedEncoding === '') {
             return false;

--- a/classes/Router.class.php
+++ b/classes/Router.class.php
@@ -300,7 +300,7 @@ class Router
             'ó' => 'o',
             'ś' => 's',
             'ż' => 'z',
-            'ź' => 'z'
+            'ź' => 'z',
         ]);
 
         $string = preg_replace('#[^a-z0-9]+#', '-', $string);

--- a/classes/Skin.class.php
+++ b/classes/Skin.class.php
@@ -138,7 +138,7 @@ abstract class Skin
     {
         $this->meta[] = [
             'name' => $name,
-            'value' => $value
+            'value' => $value,
         ];
     }
 
@@ -152,7 +152,7 @@ abstract class Skin
     {
         $this->meta[] = [
             'name' => 'robots',
-            'content' => $policy
+            'content' => $policy,
         ];
     }
 
@@ -165,7 +165,7 @@ abstract class Skin
     {
         $this->meta[] = [
             'property' => "og:{$name}",
-            'content' => $value
+            'content' => $value,
         ];
     }
 
@@ -180,7 +180,7 @@ abstract class Skin
     {
         $this->link[] = array_merge([
             'rel' => $rel,
-            'value' => $value
+            'value' => $value,
         ], $attrs);
     }
 

--- a/classes/cache/CacheFile.class.php
+++ b/classes/cache/CacheFile.class.php
@@ -20,7 +20,7 @@ class CacheFile extends Cache
         parent::__construct($settings);
 
         $app = \NanoApp::app();
-        $this->dir = isset($settings['directory']) ? $settings['directory'] : ($app->getDirectory() . '/cache');
+        $this->dir = $settings['directory'] ?? ($app->getDirectory() . '/cache');
     }
 
     /**

--- a/classes/cache/CacheRedis.class.php
+++ b/classes/cache/CacheRedis.class.php
@@ -30,10 +30,10 @@ class CacheRedis extends Cache
         parent::__construct($settings);
 
         // read settings
-        $host = isset($settings['host']) ? $settings['host'] : 'localhost';
-        $port = isset($settings['port']) ? $settings['port'] : 6379;
-        $password = isset($settings['password']) ? $settings['password'] : false;
-        $timeout = isset($settings['timeout']) ? $settings['timeout'] : 5; // Predis default is 5 sec
+        $host = $settings['host'] ?? 'localhost';
+        $port = $settings['port'] ?? 6379;
+        $password = $settings['password'] ?? false;
+        $timeout = $settings['timeout'] ?? 5; // Predis default is 5 sec
 
         // lazy connect
         $this->redis = new Client([

--- a/classes/database/DatabaseMysql.class.php
+++ b/classes/database/DatabaseMysql.class.php
@@ -90,7 +90,7 @@ class DatabaseMysql extends Database
                 });
 
                 $this->logger->info('Connected', [
-                    'time' => $time * 1000 // [ms]
+                    'time' => $time * 1000, // [ms]
                 ]);
 
                 $this->log(__METHOD__, 'connected with ' . $hostInfo, $time);
@@ -184,7 +184,7 @@ class DatabaseMysql extends Database
             $this->logger->error($shortSql, [
                 'exception' => $e,
                 'method' => $method,
-                'time' => $time * 1000 // [ms]
+                'time' => $time * 1000, // [ms]
             ]);
 
             $this->log(__METHOD__, "error #{$this->link->errno} - {$this->link->error}");
@@ -194,7 +194,7 @@ class DatabaseMysql extends Database
             $this->logger->info("SQL {$shortSql}", [
                 'method' => $method,
                 'rows' => $res instanceof mysqli_result ? $res->num_rows : ($this->link->affected_rows ?: 0),
-                'time' => $time * 1000 // [ms]
+                'time' => $time * 1000, // [ms]
             ]);
         }
 
@@ -327,7 +327,7 @@ class DatabaseMysql extends Database
         $suffix = '';
 
         if (!empty($options['ON DUPLICATE KEY UPDATE'])) {
-            list($column, $value) = $options['ON DUPLICATE KEY UPDATE'];
+            [$column, $value] = $options['ON DUPLICATE KEY UPDATE'];
             $suffix .= sprintf(' ON DUPLICATE KEY UPDATE %s = "%s"', $column, $this->escape($value));
         }
 

--- a/classes/mq/MessageQueueRedis.class.php
+++ b/classes/mq/MessageQueueRedis.class.php
@@ -35,10 +35,10 @@ class MessageQueueRedis extends MessageQueue
         parent::__construct($app, $settings);
 
         // read settings
-        $host = isset($settings['host']) ? $settings['host'] : 'localhost';
-        $port = isset($settings['port']) ? $settings['port'] : 6379;
-        $password = isset($settings['password']) ? $settings['password'] : null;
-        $timeout = isset($settings['timeout']) ? $settings['timeout'] : 5; // Predis default is 5 sec
+        $host = $settings['host'] ?? 'localhost';
+        $port = $settings['port'] ?? 6379;
+        $password = $settings['password'] ?? null;
+        $timeout = $settings['timeout'] ?? 5; // Predis default is 5 sec
 
         // lazy connect
         $this->redis = new Client([
@@ -77,7 +77,7 @@ class MessageQueueRedis extends MessageQueue
 
         // log the push()
         $this->logger->info($fname, [
-            'queue' => $this->queueName
+            'queue' => $this->queueName,
         ]);
 
         // return wrapped message
@@ -100,7 +100,7 @@ class MessageQueueRedis extends MessageQueue
 
             // log the pop()
             $this->logger->info($fname, [
-                'queue' => $this->queueName
+                'queue' => $this->queueName,
             ]);
 
             // return wrapped message
@@ -127,7 +127,7 @@ class MessageQueueRedis extends MessageQueue
     {
         $this->redis->del([
             $this->getQueueKey(),
-            $this->getLastIdKey()
+            $this->getLastIdKey(),
         ]);
     }
 

--- a/classes/utils/HttpClient.class.php
+++ b/classes/utils/HttpClient.class.php
@@ -325,7 +325,7 @@ class HttpClient
                     'total_time' => $info['total_time'] * 1000, // [ms]
                     'speed_download' => (int) $info['speed_download'],
                     'size_download' => (int) $info['size_download'],
-                ]
+                ],
             ]);
         } else {
             $e = new ResponseException(curl_error($this->handle), curl_errno($this->handle));
@@ -333,7 +333,7 @@ class HttpClient
             $this->logger->error(__METHOD__. ': ' . $e->getMessage(), [
                 'exception' => $e,
                 'method' => $method,
-                'url' => $url
+                'url' => $url,
             ]);
 
             throw $e;

--- a/classes/utils/SitemapGenerator.class.php
+++ b/classes/utils/SitemapGenerator.class.php
@@ -226,7 +226,7 @@ class SitemapGenerator
     public function addUrl($url, $lastmod = false, $priority = false /* 0.5 is the default value */)
     {
         $entry = [
-            'url' => $url
+            'url' => $url,
         ];
 
         $this->debug->log(__METHOD__ . ": {$url}");
@@ -282,7 +282,7 @@ class SitemapGenerator
         $http = new HttpClient();
 
         $res = $http->get($host . '/ping', [
-            'sitemap' => $this->router->formatFullUrl() . self::SITEMAP_FILE
+            'sitemap' => $this->router->formatFullUrl() . self::SITEMAP_FILE,
         ]);
 
         return $res->getResponseCode() === 200;

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     ],
     "lint": [
       "php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --verbose",
-      "phpstan analyse app/ classes/ tests/"
+      "phpstan --memory-limit=256M analyse app/ classes/ tests/"
     ],
     "format": [
       "php-cs-fixer fix --config=.php-cs-fixer.php"

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -19,7 +19,7 @@ abstract class CacheTest extends NanoBaseTest
 
         $settings = array_merge([
             'driver' => $driver,
-            'password' => getenv('REDIS_PASSWORD')
+            'password' => getenv('REDIS_PASSWORD'),
         ], $settings);
 
         return Cache::factory($settings);
@@ -40,13 +40,13 @@ abstract class CacheTest extends NanoBaseTest
     public function cacheFactoryProvider(): Generator
     {
         yield 'file' => [
-            'file', [], Cache\CacheFile::class
+            'file', [], Cache\CacheFile::class,
         ];
         yield 'File' => [
-            'File', [], Cache\CacheFile::class
+            'File', [], Cache\CacheFile::class,
         ];
         yield 'redis' => [
-            'redis', ['host' => '127.0.0.1'], Cache\CacheRedis::class
+            'redis', ['host' => '127.0.0.1'], Cache\CacheRedis::class,
         ];
     }
 
@@ -66,7 +66,7 @@ abstract class CacheTest extends NanoBaseTest
         $value = [
             'test' => true,
             'mixed' => [1,2,3],
-            'pi' => 3.1415
+            'pi' => 3.1415,
         ];
 
         $this->assertTrue($cache->set($key, $value, 60));

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -13,8 +13,8 @@ class OutputTest extends \Nano\NanoBaseTest
         'foo' => 'bar',
         'test' => [
             '123',
-            '456'
-        ]
+            '456',
+        ],
     ];
 
     public function testOutputFactory()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -18,7 +18,7 @@ class RequestTest extends \Nano\NanoBaseTest
             'box' => 'on',
         ],
             [
-            'REQUEST_METHOD' => 'GET'
+            'REQUEST_METHOD' => 'GET',
         ]
         );
 
@@ -68,7 +68,7 @@ class RequestTest extends \Nano\NanoBaseTest
             'box' => 'on',
         ],
             [
-            'REQUEST_METHOD' => 'POST'
+            'REQUEST_METHOD' => 'POST',
         ]
         );
 
@@ -141,7 +141,7 @@ class RequestTest extends \Nano\NanoBaseTest
             'box' => 'on',
         ],
             [
-            'REQUEST_METHOD' => 'API'
+            'REQUEST_METHOD' => 'API',
         ]
         );
 
@@ -162,7 +162,7 @@ class RequestTest extends \Nano\NanoBaseTest
             'box' => 'on',
         ],
             [
-            'REQUEST_METHOD' => 'INTERNAL'
+            'REQUEST_METHOD' => 'INTERNAL',
         ]
         );
 
@@ -182,7 +182,7 @@ class RequestTest extends \Nano\NanoBaseTest
             'box' => 'on',
         ],
             [
-            'REQUEST_METHOD' => 'CLI'
+            'REQUEST_METHOD' => 'CLI',
         ]
         );
 
@@ -200,7 +200,7 @@ class RequestTest extends \Nano\NanoBaseTest
 
         // set path directly
         $request = new Request([
-            'q' => 'foo'
+            'q' => 'foo',
         ]);
         $request->setPath($uri);
 

--- a/tests/StaticAssetsTest.php
+++ b/tests/StaticAssetsTest.php
@@ -35,9 +35,9 @@ class StaticAssetsTest extends \Nano\NanoBaseTest
             'jquery' => [
                 'js' => '/statics/jquery.foo.js',
                 'ext' => [
-                    'js' => 'http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'
-                ]
-            ]
+                    'js' => 'http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js',
+                ],
+            ],
         ]);
     }
 
@@ -138,8 +138,8 @@ class StaticAssetsTest extends \Nano\NanoBaseTest
                 'deps' => 'libFoo',
             ],
             'libTest' => [
-                'deps' => ['libBar', 'libFoo']
-            ]
+                'deps' => ['libBar', 'libFoo'],
+            ],
         ];
         $this->app->getConfig()->set('assets.packages', $packages);
 
@@ -303,7 +303,7 @@ class StaticAssetsTest extends \Nano\NanoBaseTest
 
         $this->assertEquals([
             'http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js',
-            "/site/r{$cb}/package/jquery.js"
+            "/site/r{$cb}/package/jquery.js",
         ], $static->getUrlsForPackage('jquery', 'js'));
     }
 

--- a/tests/app/config/default.config.php
+++ b/tests/app/config/default.config.php
@@ -10,7 +10,7 @@ $config['db'] = [
     'default' => [
         'driver' => 'mysql',
         'utf' => true,
-    ]
+    ],
 ];
 $config['foo']['bar'] = '123';
 $config['assets'] = [

--- a/tests/app/controllers/foo/FooController.class.php
+++ b/tests/app/controllers/foo/FooController.class.php
@@ -45,7 +45,7 @@ class FooController extends Controller
     public function json($id)
     {
         $this->setData([
-            'id' => intval($id)
+            'id' => intval($id),
         ]);
         $this->setFormat('json');
     }


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/index.rst

## Examples

### `list_syntax`

```diff
-                list($type, $callback) = $entry;
+                [$type, $callback] = $entry;
```

### `ternary_to_null_coalescing`

```diff
-        $this->prefix = isset($settings['prefix']) ? $settings['prefix'] : false;
+        $this->prefix = $settings['prefix'] ?? false;
```


### `trailing_comma_in_multiline `

```diff
                 array_merge($column_where, $where),
                 [
                     'order' => $column,
-                    'limit' => intval($batch)
+                    'limit' => intval($batch),
                 ],
```