### PR TITLE
Router - fix passing null to parameter #1 ($string) of type string is deprecated 

### DIFF
--- a/classes/Router.class.php
+++ b/classes/Router.class.php
@@ -53,7 +53,7 @@ class Router
      *
      * Trim separator and extra chars given
      */
-    private function normalize($url, $extraChars = '')
+    private function normalize(string $url, string $extraChars = ''): string
     {
         $url = rtrim($url, self::SEPARATOR . $extraChars);
         $url = ltrim($url, self::SEPARATOR);
@@ -267,7 +267,8 @@ class Router
     public function getPathPrefix()
     {
         // parse homepage's URL
-        $pathPrefix = self::SEPARATOR . $this->normalize(parse_url($this->homeUrl, PHP_URL_PATH));
+        $homeUrl = parse_url($this->homeUrl, PHP_URL_PATH) ?? '';
+        $pathPrefix = self::SEPARATOR . $this->normalize($homeUrl);
 
         if (strlen($pathPrefix) > 1) {
             $pathPrefix .= self::SEPARATOR;

--- a/classes/Router.class.php
+++ b/classes/Router.class.php
@@ -267,8 +267,8 @@ class Router
     public function getPathPrefix()
     {
         // parse homepage's URL
-        $homeUrl = parse_url($this->homeUrl, PHP_URL_PATH) ?? '';
-        $pathPrefix = self::SEPARATOR . $this->normalize($homeUrl);
+        $homeUrlPath = parse_url($this->homeUrl, PHP_URL_PATH) ?? '';
+        $pathPrefix = self::SEPARATOR . $this->normalize($homeUrlPath);
 
         if (strlen($pathPrefix) > 1) {
             $pathPrefix .= self::SEPARATOR;


### PR DESCRIPTION
Resolves #166
