### PR TITLE
httpbin: use for tests and in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,13 @@ jobs:
         - "3306:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
+      # https://github.com/postmanlabs/httpbin
+      # https://httpbin.org/
+      httpbin:
+        image: kennethreitz/httpbin
+        ports:
+        - "5555:80"
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ nano
 
 ```
 docker run -d -p 6379:6379 redis:5.0.9-alpine redis-server --requirepass qwerty --port 6379
+docker run -d -p 5555:80 kennethreitz/httpbin httpin
 composer run test
 ```
 


### PR DESCRIPTION
This will fix timeout issues with requests to httpbin.org.