### PR TITLE
CI: install xdebug and use it for coverage instead of PCOV

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,6 +53,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        coverage: xdebug
 
     - name: Print some details about PHP
       run: |


### PR DESCRIPTION
```
Coverage:  73.70% (1494/2027)
Collect git info
Read environment variables
Dump submitting json file: /tmp/coverage.json
File size: 258.31 kB
Submitting to https://coveralls.io/api/v1/jobs
Finish submitting. status: 200 OK
Accepted Job #4741574036.1
You can see the build on https://coveralls.io/jobs/119249627
elapsed time: 1.349 sec memory: 6.00 MB
```