### PR TITLE
Require the latest predis and macbre/monolog-utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     "ext-xml": "*",
     "ext-xmlwriter": "*",
     "ext-zlib": "*",
-    "predis/predis": "^2.0",
+    "predis/predis": "2.3.0",
     "monolog/monolog": "^3.3.1",
-    "macbre/monolog-utils": "^3.0.0",
+    "macbre/monolog-utils": "3.1.0",
     "tedivm/jshrink": "^1.2"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce736247b2d98034c3e5c31a492fa454",
+    "content-hash": "85968d42e90a297389cbb39d1f05178b",
     "packages": [
         {
             "name": "macbre/monolog-utils",
@@ -4540,7 +4540,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -4554,6 +4554,6 @@
         "ext-xmlwriter": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`composer require macbre/monolog-utils:3.1.0 predis/predis:2.3.0`

The latter fixes some PHP 8.4 deprecations:

```yaml
PHP Deprecated:  Predis\Client::createPipeline(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead
PHP Deprecated:  Predis\Client::createTransaction(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead
PHP Deprecated:  Predis\Client::createPubSub(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead
PHP Deprecated:  Predis\Configuration\Options::__construct(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead
```