### PR TITLE
Require PHP 8.3+

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         php-versions:
-        - '8.2'
         - '8.3'
         - '8.4'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         php-versions:
-        - '8.2'
         - '8.3'
         - '8.4'
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "ext-mysqli": "*",
     "ext-curl": "*",
     "ext-mbstring": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bca4f0b857530ef60e927690e0940309",
+    "content-hash": "3f421cf295b044985a5986e7a314963c",
     "packages": [
         {
             "name": "macbre/monolog-utils",
@@ -4609,7 +4609,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-mysqli": "*",
         "ext-curl": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
```
composer require php:^8.3
```


Branch 	Initial Release 	Active Support Until 	Security Support Until
[8.1](https://www.php.net/downloads.php#v8.1.32) 	25 Nov 2021 	3 years, 4 months ago 	25 Nov 2023 	1 year, 4 months ago 	31 Dec 2025 	in 8 months
[8.2](https://www.php.net/downloads.php#v8.2.28) 	8 Dec 2022 	2 years, 4 months ago 	31 Dec 2024 	3 months ago 	31 Dec 2026 	in 1 year, 8 months
[8.3](https://www.php.net/downloads.php#v8.3.20) 	23 Nov 2023 	1 year, 4 months ago 	31 Dec 2025 	in 8 months 	31 Dec 2027 	in 2 years, 8 months
[8.4](https://www.php.net/downloads.php#v8.4.5) 	21 Nov 2024 	4 months ago 	31 Dec 2026 	in 1 year, 8 months 	31 Dec 2028 	in 3 years, 8 months

> -- https://www.php.net/supported-versions

